### PR TITLE
Don't pass URL path and username/password to PAC scripts

### DIFF
--- a/core/java/android/net/PacProxySelector.java
+++ b/core/java/android/net/PacProxySelector.java
@@ -31,6 +31,7 @@ import java.net.Proxy.Type;
 import java.net.ProxySelector;
 import java.net.SocketAddress;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.List;
 
 /**
@@ -65,7 +66,15 @@ public class PacProxySelector extends ProxySelector {
         String response = null;
         String urlString;
         try {
+            // Strip path and username/password from URI so it's not visible to PAC script. The
+            // path often contains credentials the app does not want exposed to a potentially
+            // malicious PAC script.
+            if (!"http".equalsIgnoreCase(uri.getScheme())) {
+                uri = new URI(uri.getScheme(), null, uri.getHost(), uri.getPort(), "/", null, null);
+            }
             urlString = uri.toURL().toString();
+        } catch (URISyntaxException e) {
+            urlString = uri.getHost();
         } catch (MalformedURLException e) {
             urlString = uri.getHost();
         }


### PR DESCRIPTION
The URL path could contain credentials that apps don't want exposed
to a potentially malicious PAC script.

Bug: 27593919
Change-Id: I4bb0362fc91f70ad47c4c7453d77d6f9a1e8eeed
